### PR TITLE
Add connection hints to HELLO response

### DIFF
--- a/lib/src/bolt/mod.rs
+++ b/lib/src/bolt/mod.rs
@@ -14,7 +14,8 @@ mod structs;
 mod summary;
 
 pub use request::{
-    Begin, Commit, Discard, Goodbye, Hello, HelloBuilder, Pull, Reset, Rollback, WrapExtra,
+    Begin, Commit, ConnectionsHints, Discard, Goodbye, Hello, HelloBuilder, Pull, Reset, Rollback,
+    WrapExtra,
 };
 pub use structs::{
     Bolt, BoltRef, Date, DateDuration, DateTime, DateTimeZoneId, DateTimeZoneIdRef, Duration,
@@ -24,7 +25,7 @@ pub use structs::{
 };
 pub use summary::{Failure, Success, Summary};
 
-use crate::packstream::{self, de, from_bytes, from_bytes_ref, ser, to_bytes, Data};
+use crate::packstream::{de, from_bytes, from_bytes_ref, ser, to_bytes, Data};
 
 pub(crate) trait Message: Serialize {
     /// Serialize this type into a packstream encoded byte slice.

--- a/lib/src/bolt/request/mod.rs
+++ b/lib/src/bolt/request/mod.rs
@@ -14,7 +14,7 @@ pub use commit::Commit;
 pub use discard::Discard;
 pub use extra::WrapExtra;
 pub use goodbye::Goodbye;
-pub use hello::{Hello, HelloBuilder};
+pub use hello::{ConnectionsHints, Hello, HelloBuilder};
 pub use pull::Pull;
 pub use reset::Reset;
 pub use rollback::Rollback;


### PR DESCRIPTION
This PR adds connection hints to the HELLO response. The new object is attached to the connection but not used yet.